### PR TITLE
do not spew debug errors into the logs

### DIFF
--- a/percolate-import.php
+++ b/percolate-import.php
@@ -1451,7 +1451,7 @@ class PercolateImport
 
 
       //if (WP_DEBUG) {
-        error_log("------ Calling API ------ \nURL: ".$url."\n", 0);
+        //error_log("------ Calling API ------ \nURL: ".$url."\n", 0);
         //}
 
 


### PR DESCRIPTION
A better way to fix would be to look at wp_debug like the other commented out line indicates.